### PR TITLE
Graphics.getPaintContents can optionally resize the screenshot

### DIFF
--- a/json/protocol.json
+++ b/json/protocol.json
@@ -476,6 +476,12 @@
                             "name": "mimeType",
                             "description": "Encoding format for the returned screen.",
                             "$ref": "MimeType"
+                        },
+                        {
+                            "name": "resizeHeight",
+                            "description": "If specified, the returned screen will be scaled to the specified height.",
+                            "optional": true,
+                            "type": "integer"
                         }
                     ],
                     "returns": [

--- a/pdl/protocol.pdl
+++ b/pdl/protocol.pdl
@@ -269,6 +269,8 @@ domain Graphics
       Recording.ExecutionPoint point
       # Encoding format for the returned screen.
       MimeType mimeType
+      # If specified, the returned screen will be scaled to the specified height.
+      optional integer resizeHeight
     returns
       # Screen shot of the rendered graphics.
       ScreenShot screen


### PR DESCRIPTION
Note that I added the changes to `protocol.json` manually because `build.sh` failed for me with the following error:
```
Traceback (most recent call last):
  File "inspector_protocol/convert_protocol_to_json.py", line 35, in <module>
    sys.exit(main(sys.argv[1:]))
  File "inspector_protocol/convert_protocol_to_json.py", line 30, in main
    json.dump(protocol, output_file, indent=4, separators=(',', ': '))
  File "/usr/lib/python3.8/json/__init__.py", line 180, in dump
    fp.write(chunk)
TypeError: a bytes-like object is required, not 'str'
```
