### PR TITLE
rename the package and remove outdated dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "recordreplay-protocol",
+  "name": "record-replay-protocol",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -9,15 +9,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.1.tgz",
       "integrity": "sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==",
       "dev": true
-    },
-    "@types/ws": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
-      "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "ts-node": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "recordreplay-protocol",
+  "name": "record-replay-protocol",
   "version": "1.0.0",
   "description": "Definition of the protocol used by the Record Replay web service",
   "author": "",
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@types/node": "^14.10.1",
-    "@types/ws": "^7.2.6",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2"
   },


### PR DESCRIPTION
The package name was inconsistent with how it is being used in devtools (`recordreplay-protocol` vs. `record-replay-protocol`). As a result, running `npm update record-replay-protocol` in devtools didn't work as expected: it would install a second copy of the protocol (called `recordreplay-protocol`) and leave the version used in the code (`record-replay-protocol`) untouched.