### PR TITLE
ci: create skeleton of CI for protocol

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
+      FORCE_COLOR: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Put back the git branch into git (Earthly uses it for tagging)
+      run: |
+        branch=""
+        if [ -n "$GITHUB_HEAD_REF" ]; then
+          branch="$GITHUB_HEAD_REF"
+        else
+          branch="${GITHUB_REF##*/}"
+        fi
+        git checkout -b "$branch" || true
+    - name: Download earth
+      run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.3.19/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+    - name: Run build
+      run: earth +build


### PR DESCRIPTION
This uses earth to build in CI similarly to the backend. I'm not sure how to publish to npm, we could probably do that in earth too. I imagine it would be easier to just use some off-the-shelf action for that though. :)