### PR TITLE
Fix server types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "record-replay-protocol",
-  "version": "1.0.0",
+  "name": "@recordreplay/protocol",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/protocol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Definition of the protocol used by the Record Replay web service",
   "author": "",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This fixes the types that are generated for the server.
I have created a [branch](https://github.com/RecordReplay/backend/commit/ef88e2cd8f1bee7f355195cb7a661be0eec7cf73) in the backend repo demonstrating the use of these types:
* the `ProtocolMessageHandlers` type is used [here](https://github.com/RecordReplay/backend/blob/ef88e2cd8f1bee7f355195cb7a661be0eec7cf73/src/dispatch/analysis.ts#L166) - by adding the type on that line all the following message handlers are completely typed
* the `addMessageHandler` function type is used [here](https://github.com/RecordReplay/backend/blob/ef88e2cd8f1bee7f355195cb7a661be0eec7cf73/src/control/channel.d.ts#L5) and results in all message handlers in [`src/controls/pause.ts`](https://github.com/RecordReplay/backend/blob/ef88e2cd8f1bee7f355195cb7a661be0eec7cf73/src/control/pause.ts#L321) being completely typed
* the `sendEvent` function type is used [here](https://github.com/RecordReplay/backend/blob/ef88e2cd8f1bee7f355195cb7a661be0eec7cf73/src/dispatch/analysis.ts#L20) and results in all events in this file being typed
