### PR TITLE
add Authentication.setAccessToken

### DIFF
--- a/json/protocol.json
+++ b/json/protocol.json
@@ -343,6 +343,22 @@
             ]
         },
         {
+            "domain": "Authentication",
+            "description": "The Authentication domain defines a command for authenticating the current user.",
+            "commands": [
+                {
+                    "name": "setAccessToken",
+                    "description": "Set the user's current access token",
+                    "parameters": [
+                        {
+                            "name": "accessToken",
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "domain": "Session",
             "description": "The Session domain defines methods for using recording sessions. In order to\ninspect a recording, it must first be loaded into a session via\n<code>Recording.createSession</code>.\n\nAfter the session is created, it may be in an unprocessed or partially\nprocessed state. As documented, some commands do not return until the session\nhas fully processed the recording. Processing starts automatically after the\nsession is created.\n\n<br><br>All commands and events in this domain must include a <code>sessionId</code>.",
             "types": [
@@ -3207,16 +3223,6 @@
                             "items": {
                                 "type": "object"
                             }
-                        }
-                    ]
-                },
-                {
-                    "name": "setAccessToken",
-                    "description": "Set the user's current access token",
-                    "parameters": [
-                        {
-                            "name": "accessToken",
-                            "type": "string"
                         }
                     ]
                 }

--- a/json/protocol.json
+++ b/json/protocol.json
@@ -3209,6 +3209,16 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "setAccessToken",
+                    "description": "Set the user's current access token",
+                    "parameters": [
+                        {
+                            "name": "accessToken",
+                            "type": "string"
+                        }
+                    ]
                 }
             ],
             "types": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/protocol",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/protocol",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Definition of the protocol used by the Record Replay web service",
   "author": "",
   "license": "BSD-3-Clause",

--- a/pdl/protocol.pdl
+++ b/pdl/protocol.pdl
@@ -177,6 +177,13 @@ domain Recording
     parameters
       RecordingId recordingId
 
+# The Authentication domain defines a command for authenticating the current user.
+domain Authentication
+  # Set the user's current access token
+  command setAccessToken
+    parameters
+      string accessToken
+
 # The Session domain defines methods for using recording sessions. In order to
 # inspect a recording, it must first be loaded into a session via
 # <code>Recording.createSession</code>.
@@ -1661,8 +1668,3 @@ domain Internal
       integer duration
       string lastScreenData 
       string lastScreenMimeType  
-
-  # Set the user's current access token
-  command setAccessToken
-    parameters
-      string accessToken

--- a/pdl/protocol.pdl
+++ b/pdl/protocol.pdl
@@ -1662,4 +1662,7 @@ domain Internal
       string lastScreenData 
       string lastScreenMimeType  
 
-
+  # Set the user's current access token
+  command setAccessToken
+    parameters
+      string accessToken


### PR DESCRIPTION
This allows the devtools to send the current access token for hasura to the backend. It will be used by the backend to verify that the user is allowed to view the requested recording.